### PR TITLE
AG-137, 149 Make nodes of individuals to store only relevant hyper parameter groups 

### DIFF
--- a/benchmark/src/main/scala/com/automl/benchmark/glass/GlassDataSetBenchmark.scala
+++ b/benchmark/src/main/scala/com/automl/benchmark/glass/GlassDataSetBenchmark.scala
@@ -30,6 +30,7 @@ class GlassDataSetBenchmark(implicit as: ActorSystem) extends SparkSessionProvid
         |  hyperParameterDimension {
         |    enabled = false
         |  }
+        |  hpGridSearch = false
         |}
       """.stripMargin)
     ConfigProvider.addOverride(testOverride)

--- a/src/main/scala/com/automl/Evaluated.scala
+++ b/src/main/scala/com/automl/Evaluated.scala
@@ -9,6 +9,8 @@ trait Evaluated[T <: Evaluated[T]] {
   def result: FitnessType
   def params: Option[ParamsType]
 
+  def idShort: String
+
   def compare(other: T): Boolean
 
 }

--- a/src/main/scala/com/automl/EvaluatedTemplateData.scala
+++ b/src/main/scala/com/automl/EvaluatedTemplateData.scala
@@ -43,6 +43,13 @@ case class EvaluatedTemplateData(id: String,
     val newValue = (fitness.getCorrespondingMetric * 1000000).toLong
     kamonMetric.set(newValue)
   }
+
+  //Should be faster as we compare only certain fiels of the case class
+  override def equals(obj: Any): Boolean = {
+    require(obj.isInstanceOf[EvaluatedTemplateData])
+    val another = obj.asInstanceOf[EvaluatedTemplateData]
+    this.template == another.template && this.fitness.getCorrespondingMetric == another.fitness.getCorrespondingMetric
+  }
 }
 
 object EvaluatedTemplateData extends LazyLogging {

--- a/src/main/scala/com/automl/Wildcard.scala
+++ b/src/main/scala/com/automl/Wildcard.scala
@@ -1,5 +1,6 @@
 package com.automl
 
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.template.{EvaluationMagnet, TemplateMember}
@@ -18,7 +19,7 @@ case class Wildcard(members: Seq[TemplateMember] = SimpleModelMember.poolOfSimpl
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
     throw new IllegalStateException("We can't estimate fitnessError on wildcard for now")
   }
 

--- a/src/main/scala/com/automl/evolution/dimension/EvolutionDimension.scala
+++ b/src/main/scala/com/automl/evolution/dimension/EvolutionDimension.scala
@@ -21,7 +21,7 @@ trait EvolutionDimension[PopulationType <: Population[T], T, EvaluatedResult <: 
 
   var _population: PopulationType
 
-  var _evaluatedPopulation: Seq[EvaluatedResult] = Nil
+  var _evaluatedEvolvedPopulation: Seq[EvaluatedResult] = Nil
 
   var currentWorkingDFSize:Long = 0
 
@@ -69,7 +69,7 @@ trait EvolutionDimension[PopulationType <: Population[T], T, EvaluatedResult <: 
     debug("Selecting survivals:")
     val survivedForNextGenerationEvaluatedTemplates = selectSurvived(population.size, evaluatedOffspring)
 
-    _evaluatedPopulation = survivedForNextGenerationEvaluatedTemplates
+    _evaluatedEvolvedPopulation = survivedForNextGenerationEvaluatedTemplates
 
     val evolvedNewGeneration: PopulationType = extractIndividualsFromEvaluatedIndividuals(survivedForNextGenerationEvaluatedTemplates)
     evolvedNewGeneration.render
@@ -108,7 +108,7 @@ trait EvolutionDimension[PopulationType <: Population[T], T, EvaluatedResult <: 
 
   def getPopulation: PopulationType = if(_population.nonEmpty) _population else getInitialPopulation
 
-  def getEvaluatedPopulation: Seq[EvaluatedResult] = _evaluatedPopulation
+  def getEvaluatedPopulation: Seq[EvaluatedResult] = _evaluatedEvolvedPopulation
 
   def getLastEvaluatedPopulation(workingDF: DataFrame): Seq[EvaluatedResult] = {
     val newWorkingDFSize = workingDF.count()

--- a/src/main/scala/com/automl/evolution/dimension/TemplateEvolutionDimension.scala
+++ b/src/main/scala/com/automl/evolution/dimension/TemplateEvolutionDimension.scala
@@ -121,7 +121,7 @@ class TemplateEvolutionDimension(initialPopulation: Option[TPopulation] = None, 
     debug("Selecting survivals:")
     val survivedForNextGenerationEvaluatedTemplates = selectSurvived(population.size, evaluationResultsForNewExpandedGeneration)
 
-    _evaluatedPopulation = survivedForNextGenerationEvaluatedTemplates
+    _evaluatedEvolvedPopulation = survivedForNextGenerationEvaluatedTemplates
 
     val evolvedPopulation = new TPopulation(survivedForNextGenerationEvaluatedTemplates.map(_.template))
 

--- a/src/main/scala/com/automl/evolution/dimension/hparameter/BayesianHParameter.scala
+++ b/src/main/scala/com/automl/evolution/dimension/hparameter/BayesianHParameter.scala
@@ -1,9 +1,13 @@
 package com.automl.evolution.dimension.hparameter
 
-import scala.util.Random
+import com.automl.template.TemplateMember
+import com.automl.template.simple.Bayesian
+
 
 case class BayesianHPGroup(hpParameters:Seq[BayesianHParameter[Double]] = Seq(Smoothing()))
   extends HyperParametersGroup[BayesianHParameter[Double]] {
+
+  override def isRelevantTo(templateTree: TemplateMember): Boolean = templateTree.isInstanceOf[Bayesian]
 
   // TODO consider using HList
   override def mutate(): HyperParametersGroup[BayesianHParameter[Double]] = {

--- a/src/main/scala/com/automl/evolution/dimension/hparameter/DecisionTreeHParameter.scala
+++ b/src/main/scala/com/automl/evolution/dimension/hparameter/DecisionTreeHParameter.scala
@@ -1,11 +1,13 @@
 package com.automl.evolution.dimension.hparameter
 
-import scala.math.BigDecimal.RoundingMode
-import scala.util.Random
+import com.automl.template.TemplateMember
+import com.automl.template.simple.DecisionTree
 
 
 case class DecisionTreeHPGroup(hpParameters:Seq[DecisionTreeHParameter[Double]] = Seq(MaxDepth()))
   extends HyperParametersGroup[DecisionTreeHParameter[Double]] {
+
+  override def isRelevantTo(templateTree: TemplateMember): Boolean = templateTree.isInstanceOf[DecisionTree]
 
   override def mutate(): HyperParametersGroup[DecisionTreeHParameter[Double]] = {
     DecisionTreeHPGroup(hpParameters = hpParameters.map(hpModelTpe => hpModelTpe.mutate()))

--- a/src/main/scala/com/automl/evolution/dimension/hparameter/LogisticRegressionHParameter.scala
+++ b/src/main/scala/com/automl/evolution/dimension/hparameter/LogisticRegressionHParameter.scala
@@ -1,11 +1,15 @@
 package com.automl.evolution.dimension.hparameter
 
-import scala.math.BigDecimal.RoundingMode
+import com.automl.template.simple.LogisticRegressionModel
+import com.automl.template.{TemplateMember, TemplateTree}
+
 import scala.util.Random
 
 
 case class LogisticRegressionHPGroup(hpParameters:Seq[LogisticRegressionHParameter[Double]] = Seq(LRRegParam(), ElasticNet()))
   extends HyperParametersGroup[LogisticRegressionHParameter[Double]] {
+
+  override def isRelevantTo(templateTree: TemplateMember): Boolean = templateTree.isInstanceOf[LogisticRegressionModel]
 
   override def mutate(): HyperParametersGroup[LogisticRegressionHParameter[Double]] = {
     LogisticRegressionHPGroup(hpParameters = hpParameters.map(hpModelTpe => hpModelTpe.mutate()))

--- a/src/main/scala/com/automl/evolution/dimension/hparameter/TemplateHyperParametersEvolutionDimension.scala
+++ b/src/main/scala/com/automl/evolution/dimension/hparameter/TemplateHyperParametersEvolutionDimension.scala
@@ -9,6 +9,7 @@ import com.automl.evolution.evaluation.{HyperParameterContemporaryPopulationEval
 import com.automl.evolution.mutation.{DepthDependentTemplateMutationStrategy, HPMutationStrategy}
 import com.automl.helper.PopulationHelper
 import com.automl.population.{GenericPopulationBuilder, HPPopulation}
+import com.automl.template.{TemplateMember, TemplateTree}
 
 import scala.collection.mutable
 import scala.math.BigDecimal.RoundingMode
@@ -111,6 +112,7 @@ class TemplateHyperParametersEvolutionDimension(parentTemplateEvDimension: Templ
 trait HyperParametersGroup[HPModelBoundedType <: MutableHParameter[Double, HPModelBoundedType]]{
   def hpParameters : Seq[HPModelBoundedType]
   def mutate(): HyperParametersGroup[HPModelBoundedType]
+  def isRelevantTo(template: TemplateMember): Boolean
 } //TODO instead of using Any we can create our own hierarhy of wrapper classes to make them have coomon ancestor like ParameterType
 
 
@@ -159,6 +161,8 @@ case class EvaluatedHyperParametersField(field: HyperParametersField, score:Doub
   override type FitnessType = Double
 
   override type ParamsType = AnyVal //Unused
+
+  override def idShort: String = s"idShort: ${field.hashCode}"
 
   override def params: Option[ParamsType] = None
 

--- a/src/main/scala/com/automl/evolution/dimension/hparameter/TemplateHyperParametersEvolutionDimension.scala
+++ b/src/main/scala/com/automl/evolution/dimension/hparameter/TemplateHyperParametersEvolutionDimension.scala
@@ -112,6 +112,7 @@ class TemplateHyperParametersEvolutionDimension(parentTemplateEvDimension: Templ
 trait HyperParametersGroup[HPModelBoundedType <: MutableHParameter[Double, HPModelBoundedType]]{
   def hpParameters : Seq[HPModelBoundedType]
   def mutate(): HyperParametersGroup[HPModelBoundedType]
+  //TODO maybe it is better to use Map as for now we have only one HPGroup per model
   def isRelevantTo(template: TemplateMember): Boolean
 } //TODO instead of using Any we can create our own hierarhy of wrapper classes to make them have coomon ancestor like ParameterType
 

--- a/src/main/scala/com/automl/evolution/evaluation/TemplateNSLCEvaluator.scala
+++ b/src/main/scala/com/automl/evolution/evaluation/TemplateNSLCEvaluator.scala
@@ -72,13 +72,15 @@ class TemplateNSLCEvaluator[DistMetric <: MultidimensionalDistanceMetric](
         //TODO FIX We are storing this result in cache but not into the queue
         val fitness: FitnessResult = cache.getOrElseUpdate(cacheKey, {
 
+          individualTemplate.setLogPadding(logPaddingSize)
           materializedTemplate.setLogPadding(logPaddingSize)
-          val fitnessResult = materializedTemplate.evaluateFitness(trainingSplit, testSplit, problemType, bestHPField)
+
+          val fitnessResult = individualTemplate.evaluateFitness(trainingSplit, testSplit, problemType, bestHPField)
           debug(s"Entry $cacheKey with hashCode = ${cacheKey.hashCode()} was added to the cache with score = $fitnessResult")
           fitnessResult
         })
         val usedHPField = bestHPField.orElse(materializedTemplate.internalHyperParamsMap)
-        val result = EvaluatedTemplateData(idx.toString + ":" + materializedTemplate.id, materializedTemplate,
+        val result = EvaluatedTemplateData(idx.toString + ":" + materializedTemplate.id, individualTemplate,
           materializedTemplate, fitness, hyperParamsField = usedHPField)
         templateEvDimension.hallOfFame += result
         result

--- a/src/main/scala/com/automl/evolution/mutation/DepthDependentTemplateMutationStrategy.scala
+++ b/src/main/scala/com/automl/evolution/mutation/DepthDependentTemplateMutationStrategy.scala
@@ -59,7 +59,7 @@ class DepthDependentTemplateMutationStrategy(diversityStrategy: DiversityStrateg
         if(attempts > 1) info(s"\t\t Attempt number ${attempts - 1} was unsuccessful. Max. number of attemts from config = $maxNumberOfMutationAttempts")
         newMutant = mutateIndividual(next)
         attempts += 1
-      } while ( (population.individuals ++ res ++ populationNotToIntersectWith.individuals).contains(newMutant) && attempts < maxNumberOfMutationAttempts) // Not to overlap with itself, with recently mutated new individuals and custom individuals from `notToIntersectWith`
+      } while ( (population.individuals ++ res ++ populationNotToIntersectWith.individuals).contains(newMutant) && attempts <= maxNumberOfMutationAttempts) // Not to overlap with itself, with recently mutated new individuals and custom individuals from `notToIntersectWith`
       info(s"Mutation of the ${next.id}:${next.member.name.take(5)} individual took ${attempts-1} attempts.")
       require(attempts != maxNumberOfMutationAttempts, s"Too many attempts to mutate ${next.id} with DepthDependentTemplateMutationStrategy.") // Just to inform that probably we have some issue
       val list = newMutant +: res

--- a/src/main/scala/com/automl/evolution/selection/RankBasedSelectionProbabilityAssigner.scala
+++ b/src/main/scala/com/automl/evolution/selection/RankBasedSelectionProbabilityAssigner.scala
@@ -7,13 +7,19 @@ package com.automl.evolution.selection
   */
 class RankBasedSelectionProbabilityAssigner[T] extends SelectionProbabilityAssigner[T] {
   override def assign(items: List[T]): List[(T, Double)] = {
-    val s = 2
-    val m = items.length
-    val baselineTerm = (2 - s).toDouble / m
-    def prob(rank: Int) = baselineTerm + (2 * rank * ( s - 1)).toDouble /( m * ( m -1) )
-    items.zipWithIndex.map{ case( item, rank) =>
-      val probabilityForCurrentRank = prob(rank)
-      (item, probabilityForCurrentRank)
+    if (items.length == 1) {
+      items.map(item => (item, 1.0))
+    } else {
+      val s = 2
+      val m = items.length
+      val baselineTerm = (2 - s).toDouble / m
+
+      def prob(rank: Int) = baselineTerm + (2 * rank * (s - 1)).toDouble / (m * (m - 1))
+
+      items.zipWithIndex.map { case (item, rank) =>
+        val probabilityForCurrentRank = prob(rank)
+        (item, probabilityForCurrentRank)
+      }
     }
   }
 }

--- a/src/main/scala/com/automl/helper/PopulationHelper.scala
+++ b/src/main/scala/com/automl/helper/PopulationHelper.scala
@@ -17,7 +17,7 @@ object PopulationHelper extends PaddedLogging{
   }
 
   def renderIndividuals(individuals: Seq[TemplateTree[TemplateMember]]): String = {
-    individuals.zipWithIndex.map { case (individual, idx) => f"$idx ) ${TemplateTreeHelper.renderAsString_v2(individual)} hp: ${individual.internalHyperParamsMap.get}" }.mkString("\n\t\t\t\t\t", "\n\t\t\t\t\t", "")
+    individuals.zipWithIndex.map { case (individual, idx) => f"$idx ) ${TemplateTreeHelper.renderAsString_v2(individual)}" }.mkString("\n\t\t\t\t\t", "\n\t\t\t\t\t", "")
   }
 
   //TODO move to EvolutionDimension or a trait that will be mixed to EvolutionDimension
@@ -25,11 +25,11 @@ object PopulationHelper extends PaddedLogging{
     val prefixToPrepend = if (prefix.nonEmpty) prefix + " : \n" else prefix
     prefixToPrepend  + individuals
       .sortWith((a,b) => a.compare(b))
-      .map(evd => (evd.result, evd.item, evd.params))
+      .map(evd => (evd.idShort, evd.result, evd.item, evd.params))
       .map {
-        case ( correspondingMetric, item:HyperParametersField, _) => f" - $item $correspondingMetric"
-        case ( correspondingMetric, template:TemplateTree[TemplateMember], params: Option[HyperParametersField]) =>
-          f" - ${TemplateTreeHelper.renderAsString_v2(template)} \n Evaluation: $correspondingMetric; hps from co-evolution: $params"
+        case (idShort, correspondingMetric, item:HyperParametersField, _) => f" - $item $correspondingMetric"
+        case (idShort, correspondingMetric, template:TemplateTree[TemplateMember], params: Option[HyperParametersField]) =>
+          f" - ${TemplateTreeHelper.renderAsString_v2(template)} $idShort \t\t\t Evaluation: $correspondingMetric"
         case _ => throw new IllegalStateException("Unmanaged cases")
       }
       .mkString("\n\t\t\t\t\t", "\n\t\t\t\t\t", "")

--- a/src/main/scala/com/automl/helper/TemplateTreeHelper.scala
+++ b/src/main/scala/com/automl/helper/TemplateTreeHelper.scala
@@ -27,10 +27,10 @@ object TemplateTreeHelper {
   def traverse2(template: TemplateTree[TemplateMember]): Queue[String] = {
     def recursive(prefix: String = "", childrenPrefix: String = "", template: TemplateTree[TemplateMember], acc: Queue[String]): Queue[String] = template match {
       case lt@LeafTemplate(x) =>
-        acc.enqueue(/*"L" + */prefix + x.name + " hps: " + lt.internalHyperParamsMap)
+        acc.enqueue(/*"L" + */prefix + x.name + " hps: " + lt.internalHyperParamsMap.map(_.toString).getOrElse("--"))
         acc
       case nt@NodeTemplate(x, subMembers) =>
-        acc.enqueue(/*"N" + */prefix + x.name + " hps: " + nt.internalHyperParamsMap)
+        acc.enqueue(/*"N" + */prefix + x.name + " hps: " + nt.internalHyperParamsMap.map(_.toString).getOrElse("--"))
 
         subMembers.zipWithIndex.foldLeft(acc){case (ac, (subMember, i)) =>
           if (subMembers.size - 1 != i) {

--- a/src/main/scala/com/automl/population/HPPopulation.scala
+++ b/src/main/scala/com/automl/population/HPPopulation.scala
@@ -1,6 +1,7 @@
 package com.automl.population
 
 import com.automl.evolution.dimension.hparameter.{BayesianHPGroup, DecisionTreeHPGroup, HyperParametersField, LogisticRegressionHPGroup}
+import com.automl.template.{TemplateMember, TemplateTree}
 
 
 class HPPopulation(val individuals: Seq[ HyperParametersField])
@@ -19,10 +20,10 @@ object HPPopulation {
     )
   )
 
-  def randomHPField =
+  private val allPossibleHPGroups = Set(BayesianHPGroup(), LogisticRegressionHPGroup(), DecisionTreeHPGroup())
+
+  def randomRelevantHPFieldFor(templateMember: TemplateMember) =
     HyperParametersField(
-      Seq(
-        BayesianHPGroup(), LogisticRegressionHPGroup(), DecisionTreeHPGroup()
-      )
+      allPossibleHPGroups.filter(_.isRelevantTo(templateMember)).toSeq
     )
 }

--- a/src/main/scala/com/automl/template/TemplateTree.scala
+++ b/src/main/scala/com/automl/template/TemplateTree.scala
@@ -91,7 +91,8 @@ case class LeafTemplate[+A <: TemplateMember](member: A) extends TemplateTree[A]
 
     trainDF.cache()
     testDF.cache()
-    member.fitnessError(trainDF, testDF, problemType)
+
+    member.fitnessError(trainDF, testDF, problemType, this.internalHyperParamsMap)
   }
 
   override def height: Int = 1
@@ -162,7 +163,14 @@ trait TemplateMember { self: PaddedLogging =>
 
   //TODO could add TreeContext parameter as well
   //TODO rename to  just fitness
-  def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult
+  def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+    val msg = "Consider to use fitnessError() method with `hyperParametersField` parameter"
+    info(s"!!!!!!!!!!!! $msg")
+    throw new IllegalStateException(msg)
+    fitnessError(trainDF, testDF, problemType, None)
+  }
+
+  def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField] = None): FitnessResult
 
   override def toString: String = name
 

--- a/src/main/scala/com/automl/template/TemplateTree.scala
+++ b/src/main/scala/com/automl/template/TemplateTree.scala
@@ -38,7 +38,7 @@ sealed trait TemplateTree[+A <: TemplateMember]{
     */
   def evaluateFitness(trainingDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParamsMap: Option[HyperParametersField], seed: Long = new Random().nextLong())(implicit tc: TreeContext = TreeContext()): FitnessResult
 
-  var internalHyperParamsMap: Option[HyperParametersField] = Some(HPPopulation.randomHPField)
+  var internalHyperParamsMap: Option[HyperParametersField] = Some(HPPopulation.randomRelevantHPFieldFor(member))
 
   def height: Int = 1 + subMembers.foldLeft(1){ case (h, subMember) => Math.max(h, subMember.height)}
 

--- a/src/main/scala/com/automl/template/ensemble/EnsemblingModelMember.scala
+++ b/src/main/scala/com/automl/template/ensemble/EnsemblingModelMember.scala
@@ -15,7 +15,7 @@ trait EnsemblingModelMember extends TemplateMember { self: PaddedLogging =>
   override def name: String = "ensembling member"
 
   //TODO maybe we can reuse the same name so that we can treat Simple and Ensempling nodes equally?
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
     throw new IllegalStateException("We should call ensemblingFitnessError method for ensembling classifiers")
   }
 

--- a/src/main/scala/com/automl/template/simple/DeepNeuralNetwork.scala
+++ b/src/main/scala/com/automl/template/simple/DeepNeuralNetwork.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{MultiClassClassificationProblem, RegressionProblem}
@@ -20,5 +21,5 @@ case class DeepNeuralNetwork()(implicit val logPaddingSize: Int = 0) extends Sim
 
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = ???
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = ???
 }

--- a/src/main/scala/com/automl/template/simple/GradientBoosting.scala
+++ b/src/main/scala/com/automl/template/simple/GradientBoosting.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -24,7 +25,7 @@ case class GradientBoosting()(implicit val logPaddingSize: Int = 0) extends Simp
 
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = null
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
 
     problemType match {
       case RegressionProblem =>

--- a/src/main/scala/com/automl/template/simple/KNearestNeighbours.scala
+++ b/src/main/scala/com/automl/template/simple/KNearestNeighbours.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{MultiClassClassificationProblem, RegressionProblem}
@@ -22,6 +23,6 @@ case class KNearestNeighbours()(implicit val logPaddingSize: Int = 0) extends Si
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = ???
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = ???
 
 }

--- a/src/main/scala/com/automl/template/simple/LinearRegressionModel.scala
+++ b/src/main/scala/com/automl/template/simple/LinearRegressionModel.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -27,7 +28,7 @@ case class LinearRegressionModel()(implicit val logPaddingSize: Int = 0) extends
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
 
     logger.debug(s"Evaluating $name ...")
     val linearRegression = new LinearRegression() // It is a newer version of LinearRegressionWithSGD from mllib

--- a/src/main/scala/com/automl/template/simple/NeuralNetwork.scala
+++ b/src/main/scala/com/automl/template/simple/NeuralNetwork.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -31,7 +32,7 @@ case class NeuralNetwork(layers: Array[Int])(implicit val logPaddingSize: Int = 
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
 
     val numFeatures = trainDF.select(col("features")).first().getAs[Vector](0).size
 

--- a/src/main/scala/com/automl/template/simple/OneVsRestModel.scala
+++ b/src/main/scala/com/automl/template/simple/OneVsRestModel.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -23,7 +24,7 @@ case class OneVsRestModel()(implicit val logPaddingSize: Int = 0) extends Simple
 
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = null
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
 
     problemType match {
       case MultiClassClassificationProblem | BinaryClassificationProblem=>

--- a/src/main/scala/com/automl/template/simple/RandomForest.scala
+++ b/src/main/scala/com/automl/template/simple/RandomForest.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -27,7 +28,7 @@ case class RandomForest()(implicit val logPaddingSize: Int = 0) extends SimpleMo
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
 
     //We can iterate over HLIST and use
     // new RandomForestRegressor().set()

--- a/src/main/scala/com/automl/template/simple/SVMModel.scala
+++ b/src/main/scala/com/automl/template/simple/SVMModel.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -30,7 +31,7 @@ case class SVMModel()(implicit val logPaddingSize: Int = 0) extends LinearModelM
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = {
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = {
     logger.debug(s"Evaluating $name ...")
     import utils.SparkMLUtils._
     problemType match {

--- a/src/main/scala/com/automl/template/simple/SimpleModelMember.scala
+++ b/src/main/scala/com/automl/template/simple/SimpleModelMember.scala
@@ -1,10 +1,12 @@
 package com.automl.template.simple
 
+import com.automl.evolution.dimension.hparameter.{HyperParametersField, HyperParametersGroup}
 import com.automl.{ConfigProvider, PaddedLogging}
 import com.automl.problemtype.ProblemType
 import com.automl.template._
 import com.automl.template.simple.perceptron.LinearPerceptron
 import com.automl.teststrategy.TestStrategy
+import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
 
@@ -16,6 +18,18 @@ trait SimpleModelMember extends TemplateMember { self: PaddedLogging =>
   def modelKey: ModelKey = ???
 
   def testStrategy: TestStrategy = ???
+
+  /**
+    * Selects hpGroup based on the way how we decided to derive it. Either from coevolution or through regular mutation from TemplateTree
+    */
+  def getActiveHPGroup(config: Config, hpGroup: HyperParametersGroup[_], hyperParametersField: Option[HyperParametersField]) = {
+    val hpCoevolutionIsEnabled = config.getBoolean("hyperParameterDimension.enabled")
+
+    // It is assumed that we have only one relevant HPGroup per model
+    def getRelevantHPGroup = hyperParametersField.get.modelsHParameterGroups.filter(_.isRelevantTo(this)).head
+
+    if (hpCoevolutionIsEnabled) hpGroup else getRelevantHPGroup
+  }
 }
 
 object SimpleModelMember {

--- a/src/main/scala/com/automl/template/simple/SupportVectorRegression.scala
+++ b/src/main/scala/com/automl/template/simple/SupportVectorRegression.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -25,6 +26,6 @@ case class SupportVectorRegression()(implicit val logPaddingSize: Int = 0) exten
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = ???
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = ???
 
 }

--- a/src/main/scala/com/automl/template/simple/perceptron/LinearPerceptron.scala
+++ b/src/main/scala/com/automl/template/simple/perceptron/LinearPerceptron.scala
@@ -1,6 +1,7 @@
 package com.automl.template.simple.perceptron
 
 import com.automl.PaddedLogging
+import com.automl.evolution.dimension.hparameter.HyperParametersField
 import com.automl.helper.FitnessResult
 import com.automl.problemtype.ProblemType
 import com.automl.problemtype.ProblemType.{BinaryClassificationProblem, MultiClassClassificationProblem, RegressionProblem}
@@ -23,6 +24,6 @@ case class LinearPerceptron()(implicit val logPaddingSize: Int = 0) extends Line
   override def fitnessError(magnet: EvaluationMagnet): FitnessResult = ???
 
 
-  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType): FitnessResult = ???
+  override def fitnessError(trainDF: DataFrame, testDF: DataFrame, problemType: ProblemType, hyperParametersField: Option[HyperParametersField]): FitnessResult = ???
 
 }

--- a/src/test/scala/com/automl/evolution/selection/RankBasedSelectionProbabilityAssignerTest.scala
+++ b/src/test/scala/com/automl/evolution/selection/RankBasedSelectionProbabilityAssignerTest.scala
@@ -44,5 +44,14 @@ class RankBasedSelectionProbabilityAssignerTest extends WordSpec with Matchers{
       assigned(4)._2 shouldBe 0.4 +- 0.01
     }
 
+    "get assigned probabilities for list of one element" in {
+
+      val items = List(0.2)
+
+      val assigned =  new RankBasedSelectionProbabilityAssigner[Double].assign(items)
+
+      assigned(0)._2 shouldBe 1.0 +- 0.01
+    }
+
   }
 }

--- a/src/test/scala/com/automl/population/HPPopulationTest.scala
+++ b/src/test/scala/com/automl/population/HPPopulationTest.scala
@@ -1,0 +1,17 @@
+package com.automl.population
+
+import com.automl.evolution.dimension.hparameter.BayesianHPGroup
+import com.automl.template.simple.Bayesian
+import org.scalatest.{FunSuite, Matchers}
+
+class HPPopulationTest extends FunSuite with Matchers{
+
+  test("That `randomRelevantHPFieldFor` method will return relevant hp group") {
+    val bayesian = Bayesian()
+    val relevantHPGroup = HPPopulation.randomRelevantHPFieldFor(bayesian)
+
+    relevantHPGroup.modelsHParameterGroups.size shouldBe 1
+    relevantHPGroup.modelsHParameterGroups should contain theSameElementsAs( Seq(BayesianHPGroup()))
+  }
+
+}

--- a/src/test/scala/com/automl/template/TemplateTreeTest.scala
+++ b/src/test/scala/com/automl/template/TemplateTreeTest.scala
@@ -2,7 +2,8 @@ package com.automl.template
 
 import com.automl.classifier.ensemble.bagging.SparkGenericBagging
 import com.automl.dataset.Datasets
-import com.automl.evolution.dimension.hparameter.HyperParametersField
+import com.automl.evolution.dimension.hparameter._
+import com.automl.evolution.mutation.HPMutationStrategy
 import com.automl.problemtype.ProblemType
 import com.automl.template.simple.{Bayesian, DecisionTree, RandomForest}
 import org.scalatest.{FunSuite, Matchers}
@@ -217,5 +218,20 @@ class TemplateTreeTest extends FunSuite with Matchers {
 
     val L1DT: HyperParametersField = individual.subMembers(0).internalHyperParamsMap.get
     L0Bag shouldNot equal(L1DT)
+  }
+
+  test("hyperparameters are being taken into account when we compare templates") {
+
+    val individual: TemplateTree[TemplateMember] = LeafTemplate(DecisionTree())
+
+    val individual2: TemplateTree[TemplateMember] = LeafTemplate(DecisionTree())
+    individual2.internalHyperParamsMap = Some(HyperParametersField(
+      Seq(
+        DecisionTreeHPGroup(Seq(MaxDepth(Some(2.0))))
+      )
+    ))
+
+    individual should equal(individual)
+    individual shouldNot equal(individual2)
   }
 }

--- a/src/test/scala/com/automl/template/simple/GradientBoostingTest.scala
+++ b/src/test/scala/com/automl/template/simple/GradientBoostingTest.scala
@@ -25,7 +25,7 @@ class GradientBoostingTest extends FunSuite with SparkSessionProvider{
     val featuresAssembled = basePredictorsFeaturesAssembler.transform(preparedData)
 
     val Array(trainingSplit, testSplit) = featuresAssembled.randomSplit(Array(0.67, 0.33), 11L)
-    val res: FitnessResult = GradientBoosting().fitnessError(trainingSplit, testSplit, problemType = MultiClassClassificationProblem)
+    val res: FitnessResult = GradientBoosting().fitnessError(trainingSplit, testSplit, problemType = MultiClassClassificationProblem, None)
     res.metricsMap
 
   }
@@ -44,7 +44,7 @@ class GradientBoostingTest extends FunSuite with SparkSessionProvider{
     val featuresAssembled = basePredictorsFeaturesAssembler.transform(preparedData)
 
     val Array(trainingSplit, testSplit) = featuresAssembled.randomSplit(Array(0.67, 0.33), 11L)
-    val res: FitnessResult = GradientBoosting().fitnessError(trainingSplit, testSplit, problemType = BinaryClassificationProblem)
+    val res: FitnessResult = GradientBoosting().fitnessError(trainingSplit, testSplit, problemType = BinaryClassificationProblem, None)
     res.metricsMap
 
     // TODO transform multiclass task to a binary one or choose another dataset for test.


### PR DESCRIPTION
Changed equal method of EvaluatedTemplateData class. Fixes propagation of the stale templates into next generations.